### PR TITLE
Change opacity of text only when todo completes

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,7 +102,7 @@ form button:hover {
 
 .completed {
   text-decoration: line-through;
-  opacity: 0.5;
+  background-color: rgba(255,255,255,0.5);
 }
 
 .fall {


### PR DESCRIPTION
When a todo is completed, the whole wrapper of todo changes opacity to 0.5 which distorts the UI. Its better to change the opacity of the text only.